### PR TITLE
Injecting debug logger instead of hard-coding it

### DIFF
--- a/src/CometD.NetCore/Client/Transport/LongPollingTransport.cs
+++ b/src/CometD.NetCore/Client/Transport/LongPollingTransport.cs
@@ -17,10 +17,7 @@ namespace CometD.NetCore.Client.Transport
     /// </version>
     public class LongPollingTransport : HttpClientTransport
     {
-        private static ILogger _logger = new LoggerFactory()
-            .AddConsole(LogLevel.Debug)
-            .AddDebug()
-            .CreateLogger(nameof(LongPollingTransport));
+        private static ILogger _logger;
 
         private List<TransportExchange> _exchanges = new List<TransportExchange>();
         private List<LongPollingRequest> transportQueue = new List<LongPollingRequest>();

--- a/src/CometD.NetCore/Client/Transport/LongPollingTransport.cs
+++ b/src/CometD.NetCore/Client/Transport/LongPollingTransport.cs
@@ -17,7 +17,7 @@ namespace CometD.NetCore.Client.Transport
     /// </version>
     public class LongPollingTransport : HttpClientTransport
     {
-        private static ILogger logger = new LoggerFactory()
+        private static ILogger _logger = new LoggerFactory()
             .AddConsole(LogLevel.Debug)
             .AddDebug()
             .CreateLogger(nameof(LongPollingTransport));
@@ -31,6 +31,12 @@ namespace CometD.NetCore.Client.Transport
         public LongPollingTransport(IDictionary<string, object> options, NameValueCollection headers)
             : base("long-polling", options, headers)
         {
+        }
+
+        public LongPollingTransport(IDictionary<string, object> options, NameValueCollection headers, ILogger logger)
+            : this(options, headers)
+        {
+            _logger = logger;
         }
 
         public override bool Accept(string bayeuxVersion)
@@ -180,7 +186,7 @@ namespace CometD.NetCore.Client.Transport
 
             var content = JsonConvert.SerializeObject(ObjectConverter.ToListOfDictionary(messages));
 
-            logger.LogDebug($"Send: {content}");
+            _logger?.LogDebug($"Send: {content}");
 
             var longPollingRequest = new LongPollingRequest(listener, messages, request);
 


### PR DESCRIPTION
The hardcoded logger for `LongPollingTransport` caught me by surprise, 
so I'm removing it here. Providing a constructor overload to inject it instead.

Props to kdcllc for the awesome work in the first place, made my life simple!