### PR TITLE
Switch more console writelines to injected loggers

### DIFF
--- a/src/CometD.NetCore/Client/BayeuxClient.cs
+++ b/src/CometD.NetCore/Client/BayeuxClient.cs
@@ -12,9 +12,10 @@ using Newtonsoft.Json.Linq;
 
 namespace CometD.NetCore.Client
 {
-    /// <summary> </summary>
     public class BayeuxClient : AbstractClientSession, IBayeux
     {
+        private readonly ILogger logger;
+
         //private static ILogger<BayeuxClient> = new LoggerFactory()
         public const string BACKOFF_INCREMENT_OPTION = "backoffIncrement";
         public const string MAX_BACKOFF_OPTION = "maxBackoff";
@@ -35,18 +36,20 @@ namespace CometD.NetCore.Client
 
         public BayeuxClient(string url, params ClientTransport[] transports)
         {
-            //logger = Log.getLogger(GetType().FullName + "@" + this.GetHashCode());
-            //Console.WriteLine(GetType().FullName + "@" + this.GetHashCode());
-
             handshakeListener = new HandshakeTransportListener(this);
             connectListener = new ConnectTransportListener(this);
             disconnectListener = new DisconnectTransportListener(this);
             publishListener = new PublishTransportListener(this);
 
-            if (transports == null || transports.Length == 0 || transports[0] == null)
-            {
+            if (transports == null)
                 throw new ArgumentNullException(nameof(transports));
-            }
+
+            if (transports.Length == 0)
+                throw new ArgumentException("No transports provided", nameof(transports));
+
+            if (transports.Any(t => t == null))
+                throw new ArgumentException("One of the transports was null", nameof(transports));
+
 
             foreach (var t in transports)
             {
@@ -66,6 +69,12 @@ namespace CometD.NetCore.Client
             bayeuxClientState = new DisconnectedState(this, null);
         }
 
+        public BayeuxClient(string url, ILogger logger, params ClientTransport[] transports)
+            : this(url, transports)
+        {
+            this.logger = logger;
+        }
+
         #region AbstractClientSession overrides
 
         #region IClientSession
@@ -82,7 +91,9 @@ namespace CometD.NetCore.Client
             // Pick the first transport for the handshake, it will renegotiate if not right
             var initialTransport = transportRegistry.GetTransport(allowedTransports[0]);
             initialTransport.Init();
-            //Console.WriteLine("Using initial transport {0} from {1}", initialTransport.Name, Print.List(allowedTransports));
+
+            logger?.LogDebug(  $"Using initial transport {initialTransport.Name}"
+                             + $" from {Print.List(allowedTransports)}");
 
             UpdateBayeuxClientState(
                     delegate (BayeuxClientState oldState)
@@ -257,12 +268,7 @@ namespace CometD.NetCore.Client
 
         public virtual void OnFailure(Exception e, IList<IMessage> messages)
         {
-            //if (!(e is WebException) || ((WebException)e).Status != WebExceptionStatus.Timeout)
-            //{
-            // the normal flow of cometd long polling is to timeout after the configured timeout value
-            // and then reconnect again, so ignore those
-            Console.WriteLine("{0}", e);
-            //}
+            logger?.LogError($"{e}");
         }
 
         #endregion
@@ -307,7 +313,10 @@ namespace CometD.NetCore.Client
                     message.Id = NewMessageId();
                 }
 
-                //Console.WriteLine("Handshaking with extra fields {0}, transport {1}", Print.Dictionary(bayeuxClientState.handshakeFields), Print.Dictionary(bayeuxClientState.transport as IDictionary<string, object>));
+                logger?.LogDebug("Handshaking with extra fields {0}, transport {1}",
+                                 Print.Dictionary(bayeuxClientState.handshakeFields),
+                                 Print.Dictionary(bayeuxClientState.transport as IDictionary<string, object>));
+
                 bayeuxClientState.Send(handshakeListener, message);
                 return true;
             }
@@ -346,10 +355,10 @@ namespace CometD.NetCore.Client
                             });
 
                     // Signal the failure
-                    var error = "405:c" + transportRegistry.AllowedTransports + ",s" + serverTransports.ToString() + ":no transport";
-
                     handshake.Successful = false;
-                    handshake[MessageFields.ERROR_FIELD] = error;
+                    handshake[MessageFields.ERROR_FIELD] =
+                            $"405:c{transportRegistry.AllowedTransports},s{serverTransports}:no transport";
+
                     // TODO: also update the advice with reconnect=none for listeners ?
                 }
                 else
@@ -694,12 +703,13 @@ namespace CometD.NetCore.Client
                     message
                 };
                 var sent = SendMessages(messages);
-                //Console.WriteLine("{0} message {1}", sent?"Sent":"Failed", message);
+
+                logger?.LogDebug("{0} message {1}", sent ? "Sent":"Failed", message);
             }
             else
             {
                 messageQueue.Enqueue(message);
-                //Console.WriteLine("Enqueued message {0} (batching: {1})", message, this.Batching);
+                logger?.LogDebug($"Enqueued message {message} (batching: {Batching})");
             }
         }
 
@@ -730,7 +740,7 @@ namespace CometD.NetCore.Client
 
             if (!oldState.IsUpdateableTo(newState))
             {
-                //Console.WriteLine("State not updateable : {0} -> {1}", oldState, newState);
+                logger?.LogDebug($"State not updateable : {oldState} -> {newState}");
                 return;
             }
 

--- a/src/CometD.NetCore/Client/BayeuxClient.cs
+++ b/src/CometD.NetCore/Client/BayeuxClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Timers;

--- a/src/CometD.NetCore/Client/Extension/ErrorExtension.cs
+++ b/src/CometD.NetCore/Client/Extension/ErrorExtension.cs
@@ -1,13 +1,21 @@
 ﻿using System;
 using CometD.NetCore.Bayeux;
 using CometD.NetCore.Bayeux.Client;
+using Microsoft.Extensions.Logging;
 
 namespace CometD.NetCore.Client.Extension
 {
     public class ErrorExtension : IExtension
     {
+        private readonly ILogger logger;
+
         public ErrorExtension()
         {
+        }
+
+        public ErrorExtension(ILogger logger)
+        {
+            this.logger = logger;
         }
 
         public event EventHandler<string> ConnectionMessage;
@@ -46,7 +54,7 @@ namespace CometD.NetCore.Client.Extension
         /// </example>
         public bool ReceiveMeta(IClientSession session, IMutableMessage message)
         {
-            Console.WriteLine($"ReceiveMeta: {message}");
+            logger?.LogDebug($"ReceiveMeta: {message}");
 
             if (message.Successful)
             {
@@ -79,7 +87,7 @@ namespace CometD.NetCore.Client.Extension
 
         public bool SendMeta(IClientSession session, IMutableMessage message)
         {
-            Console.WriteLine($"SendMeta: {message}");
+            logger?.LogDebug($"SendMeta: {message}");
 
             return true;
         }

--- a/src/CometD.NetCore/Common/AbstractSessionChannel.cs
+++ b/src/CometD.NetCore/Common/AbstractSessionChannel.cs
@@ -2,22 +2,32 @@
 using System.Collections.Generic;
 using CometD.NetCore.Bayeux;
 using CometD.NetCore.Bayeux.Client;
+using Microsoft.Extensions.Logging;
 
 namespace CometD.NetCore.Common
 {
     /// <summary> <p>A channel scoped to a {@link ClientSession}.</p></summary>
     public abstract class AbstractSessionChannel : IClientSessionChannel
     {
+        private readonly ILogger _logger;
+
         private Dictionary<string, object> _attributes = new Dictionary<string, object>();
         private List<IClientSessionChannelListener> _listeners = new List<IClientSessionChannelListener>();
         private int _subscriptionCount = 0;
         private List<IMessageListener> _subscriptions = new List<IMessageListener>();
 
         public long ReplayId { get; private set; }
+
         protected AbstractSessionChannel(ChannelId id, long replayId)
         {
             ReplayId = replayId;
             ChannelId = id;
+        }
+
+        protected AbstractSessionChannel(ChannelId id, long replayId, ILogger logger)
+            : this(id, replayId)
+        {
+            _logger = logger;
         }
 
         #region IClientSessionChannel
@@ -123,10 +133,9 @@ namespace CometD.NetCore.Common
                     {
                         ((IMessageListener)listener).OnMessage(this, message);
                     }
-                    catch (Exception x)
+                    catch (Exception e)
                     {
-                        Console.WriteLine("{0}", x);
-                        //logger.info(x);
+                        _logger?.LogError($"{e}");
                     }
                 }
             }
@@ -142,10 +151,9 @@ namespace CometD.NetCore.Common
                         {
                             ((IMessageListener)listener).OnMessage(this, message);
                         }
-                        catch (System.Exception x)
+                        catch (Exception e)
                         {
-                            Console.WriteLine("{0}", x);
-                            //logger.info(x);
+                            _logger?.LogError($"{e}");
                         }
                     }
                 }

--- a/src/CometD.NetCore/Common/DictionaryMessage.cs
+++ b/src/CometD.NetCore/Common/DictionaryMessage.cs
@@ -149,17 +149,11 @@ namespace CometD.NetCore.Common
 
         public static IList<IMutableMessage> ParseMessages(string content)
         {
-            IList<IDictionary<string, object>> dictionaryList = null;
-            try
-            {
-                dictionaryList = JsonConvert.DeserializeObject<IList<IDictionary<string, object>>>(content);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Exception when parsing json {0}", e);
-            }
+            // Will throw when unable to parse -- letting the consumer decide what to do about that.
+            var dictionaryList = JsonConvert.DeserializeObject<IList<IDictionary<string, object>>>(content);
 
-            IList<IMutableMessage> messages = new List<IMutableMessage>();
+            var messages = new List<IMutableMessage>();
+
             if (dictionaryList == null)
             {
                 return messages;


### PR DESCRIPTION
I was missing the option to turn off the `stdout` spam from a few `Console.WriteLine(...)` statements. 

I switched the implementation to be silent by default, unless injected with an instance of a logger. Non-breaking change from the API point of view. Also now that the logger is a deliberate decision, I uncommented some of the commented debug statements -- they seemed like they could be handy. Letting the consumer who provides the logger worry about the amount of info.

Again, props to kdcllc for the awesome work in the first place!