### PR TITLE
Honor the server-provided timeout advice when making long-polling requests

### DIFF
--- a/src/CometD.NetCore/Bayeux/MessageFields.cs
+++ b/src/CometD.NetCore/Bayeux/MessageFields.cs
@@ -30,6 +30,7 @@
         public const string SUBSCRIPTION_FIELD = "subscription";
         public const string SUCCESSFUL_FIELD = "successful";
         public const string SUPPORTED_CONNECTION_TYPES_FIELD = "supportedConnectionTypes";
+        public const string TIMEOUT_FIELD = "timeout";
         public const string TIMESTAMP_FIELD = "timestamp";
         public const string TRANSPORT_FIELD = "transport";
         public const string VERSION_FIELD = "version";

--- a/src/CometD.NetCore/Client/BayeuxClient.cs
+++ b/src/CometD.NetCore/Client/BayeuxClient.cs
@@ -1187,7 +1187,7 @@ namespace CometD.NetCore.Client
                     int adviceTimeoutValue = Convert.ToInt32(adviceTimeoutField);
                     if (adviceTimeoutValue != 0)
                     {
-                        _bayeuxClient.ScheduleConnect(Interval, Backoff, adviceTimeoutValue);
+                        _bayeuxClient?.ScheduleConnect(Interval, Backoff, adviceTimeoutValue);
                         return;
                     }
                 }

--- a/src/CometD.NetCore/Client/Transport/ClientTransport.cs
+++ b/src/CometD.NetCore/Client/Transport/ClientTransport.cs
@@ -7,6 +7,7 @@ namespace CometD.NetCore.Client.Transport
 {
     public abstract class ClientTransport : AbstractTransport
     {
+        public const int DEFAULT_TIMEOUT = 120000;
         public const string INTERVAL_OPTION = "interval";
         public const string MAX_NETWORK_DELAY_OPTION = "maxNetworkDelay";
         public const string TIMEOUT_OPTION = "timeout";
@@ -34,6 +35,6 @@ namespace CometD.NetCore.Client.Transport
         /// <param name="listener"></param>
         /// <param name="messages"></param>
         /// <param name="requestTimeOut">Default timeout for the request is 2min or 120000 seconds.</param>
-        public abstract void Send(ITransportListener listener, IList<IMutableMessage> messages, int requestTimeOut = 120000);
+        public abstract void Send(ITransportListener listener, IList<IMutableMessage> messages, int requestTimeOut);
     }
 }


### PR DESCRIPTION
This is in reference to #13.

When making connect calls, set the timeout value of the HttpWebRequest according to the server's advice plus a configurable network delay.

This should help in cases where the server's preferred long polling timeout is longer than the HttpWebRequest's default timeout of 100s.